### PR TITLE
Avoid confusing rclone with RCLONE_* environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 LABEL Justin Tien <thitbbeb@gmail.com>
 
-ENV RCLONE_VERSION=current
+ENV RC_VERSION=current
 ENV ARCH=amd64
 
 RUN apk update \
@@ -11,8 +11,8 @@ RUN apk update \
         ca-certificates \
         fuse \
     && cd /tmp \
-    && wget -q http://downloads.rclone.org/rclone-${RCLONE_VERSION}-linux-${ARCH}.zip \
-    && unzip /tmp/rclone-${RCLONE_VERSION}-linux-${ARCH}.zip \
+    && wget -q http://downloads.rclone.org/rclone-${RC_VERSION}-linux-${ARCH}.zip \
+    && unzip /tmp/rclone-${RC_VERSION}-linux-${ARCH}.zip \
     && mv /tmp/rclone-*-linux-${ARCH}/rclone /usr/bin \
     && rm -r /tmp/rclone* \
     && addgroup rclone \


### PR DESCRIPTION
Recent rclone binaries get confused with the use of  RCLONE_* environment variables.  A simple variable name change fixes this.